### PR TITLE
Add TinyUSB Lib Dependency

### DIFF
--- a/Embedded Software/Bollete Wing/platformio.ini
+++ b/Embedded Software/Bollete Wing/platformio.ini
@@ -12,3 +12,4 @@
 platform = atmelavr
 board = 32u416m
 framework = arduino
+lib_deps = adafruit/Adafruit TinyUSB Library@^2.2.7


### PR DESCRIPTION
Add dependency to Adafruit TinyUSB Library. Support multiple controllers.